### PR TITLE
Comando único que exibe caronas de ida/volta na 

### DIFF
--- a/Classes/Roteador.php
+++ b/Classes/Roteador.php
@@ -167,6 +167,21 @@
 						}
 						break;
 
+					case 'dia':
+						$resultado = $dao->getListaIda($chat_id);
+						$texto = "<b>Ida para o Fundão</b>\n";
+						foreach ($resultado as $carona){
+							$texto .= (string)$carona . "\n";
+						}
+						$resultado = $dao->getListaVolta($chat_id);
+						$texto .= "<b>Volta do Fundão</b>\n";
+						foreach ($resultado as $carona){
+							$texto .= (string)$carona . "\n";
+						}
+
+						TelegramConnect::sendMessage($chat_id, $texto);
+						break;
+
 					case 'remover':
 						if($args[1] == 'ida'){
 							$dao->removerIda($chat_id, $user_id);

--- a/Classes/Roteador.php
+++ b/Classes/Roteador.php
@@ -83,6 +83,8 @@
 					case 'help':
 						$help = "Utilize este Bot para agendar as caronas. A utilização é super simples e através de comandos:
 
+								/dia --> Este comando serve para exibir todas as caronas do dia.
+
 								/ida [horario] --> Este comando serve para definir um horário que você está INDO para o FUNDÃO. Ex: /ida 10:00
 								Caso não seja colocado o parâmetro do horário (Ex: /ida) o bot irá apresentar a lista com as caronas registradas para o trajeto.
 


### PR DESCRIPTION
Fala pessoal, primeiramente parabéns pela iniciativa! Sou formado no fundão em ECI e faço parte do grupo de caronas da freguesia, que usava exclusivamente o whatsapp mas estouramos o número de usuários e estamos migrando de vez para o telegram.

O pessoal do grupo pediu para ter um comando que mostrasse todas as caronas do dia (idas/voltas) numa mesma mensagem. O que eu fiz foi criar um comando `/dia` que mostra o dia, baseado na lógica que existe no `Roteador.php`. Preferi não refatorar umas coisas porque não manjo nada de php :cry: 

Espero que ajude! Qualquer ajuste só me avisar!

